### PR TITLE
GitHubリポジトリへのリンク追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(open:*)"
+      "Bash(open:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
                 <a href="legal/privacy.html">プライバシーポリシー</a>
                 <a href="legal/terms.html">利用規約</a>
                 <a href="legal/disclaimer.html">免責事項</a>
+                <a href="https://github.com/MiUPa/mercari-print" target="_blank" rel="noopener noreferrer">GitHub</a>
             </nav>
         </div>
     </footer>

--- a/legal/disclaimer.html
+++ b/legal/disclaimer.html
@@ -151,7 +151,7 @@
             <p>運営者の責任は、故意または重過失がある場合を除き、一切負わないものとします。</p>
 
             <h2>11. お問い合わせ</h2>
-            <p>本免責事項に関するお問い合わせは、GitHubリポジトリのIssuesよりお願いいたします。</p>
+            <p>本免責事項に関するお問い合わせは、<a href="https://github.com/MiUPa/mercari-print/issues" target="_blank" rel="noopener noreferrer">GitHubリポジトリのIssues</a>よりお願いいたします。</p>
         </div>
         
         <div class="back-link">

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -133,7 +133,7 @@
             <p>本プライバシーポリシーは必要に応じて変更する場合があります。重要な変更については、サイト上で告知いたします。</p>
 
             <h2>10. お問い合わせ</h2>
-            <p>本プライバシーポリシーに関するお問い合わせは、GitHubリポジトリのIssuesよりお願いいたします。</p>
+            <p>本プライバシーポリシーに関するお問い合わせは、<a href="https://github.com/MiUPa/mercari-print/issues" target="_blank" rel="noopener noreferrer">GitHubリポジトリのIssues</a>よりお願いいたします。</p>
         </div>
         
         <div class="back-link">

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -116,7 +116,7 @@
             <p>本規約は日本法に準拠し、本サービスに関する紛争については、東京地方裁判所を第一審の専属的合意管轄裁判所とします。</p>
 
             <h2>第11条（お問い合わせ）</h2>
-            <p>本規約に関するお問い合わせは、GitHubリポジトリのIssuesよりお願いいたします。</p>
+            <p>本規約に関するお問い合わせは、<a href="https://github.com/MiUPa/mercari-print/issues" target="_blank" rel="noopener noreferrer">GitHubリポジトリのIssues</a>よりお願いいたします。</p>
         </div>
         
         <div class="back-link">


### PR DESCRIPTION
## Summary
法的文書とメインページにGitHubリポジトリへのリンクを追加しました。

### 主な変更点
- **法的文書の改善**: プライバシーポリシー、利用規約、免責事項の「お問い合わせ」セクションにGitHub Issuesへの直接リンクを追加
- **メインページ更新**: フッターにGitHubリポジトリへのリンクを追加
- **セキュリティ対策**: すべての外部リンクに`target="_blank"`と`rel="noopener noreferrer"`を設定

### ユーザビリティ向上
- ユーザーが問い合わせやフィードバックを簡単に送信できるようになりました
- GitHubリポジトリへのアクセスが容易になりました
- 法的文書で言及していたGitHubへの実際のリンクが提供されました

## Test plan
- [ ] 各法的文書のGitHubリンクが正しく動作することを確認
- [ ] メインページのフッターリンクが正しく動作することを確認
- [ ] すべてのリンクが新しいタブで開くことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)